### PR TITLE
feat(react): add react-props-destructuring/no-multiline rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,8 +73,9 @@
         }
     },
     "dependencies": {
-        "@typescript-eslint/parser": "^4.0.0",
+        "@strdr4605/eslint-plugin-react-props-destructuring": "^1.0.2",
         "@typescript-eslint/eslint-plugin": "^4.0.0",
+        "@typescript-eslint/parser": "^4.0.0",
         "eslint": "^7.0.0",
         "eslint-config-prettier": "^8.0.0",
         "eslint-import-resolver-typescript": "^2.0.0",

--- a/src/react.ts
+++ b/src/react.ts
@@ -1,6 +1,6 @@
 export = {
     extends: ['plugin:react/recommended'],
-    plugins: ['react-hooks'],
+    plugins: ['react-hooks', '@strdr4605/react-props-destructuring'],
     rules: {
         'react/prop-types': 'off',
         'react/display-name': 'off',
@@ -12,5 +12,6 @@ export = {
                 props: 'never',
             },
         ],
+        '@strdr4605/react-props-destructuring/no-multiline': 'warn',
     },
 };


### PR DESCRIPTION
## Summary

Adding [react-props-destructuring/no-multiline rule](https://github.com/strdr4605/eslint-plugin-react-props-destructuring/blob/master/rules/no-multiline.md)

## Context

We were discussing this rule a long time ago at @goparrot frontend meeting.
@dobrea-v, see if the team needs it!

