### PR TITLE
style: restrict eslint-import-resolver-typescript to patch updates only

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
     "name": "@goparrot/eslint-config",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@goparrot/eslint-config",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "license": "ISC",
             "dependencies": {
                 "@typescript-eslint/eslint-plugin": "^7.3.1",
                 "@typescript-eslint/parser": "^7.3.1",
                 "eslint": "^8.57.0",
                 "eslint-config-prettier": "^9.1.0",
-                "eslint-import-resolver-typescript": "^3.6.1",
+                "eslint-import-resolver-typescript": "3.6.0",
                 "eslint-plugin-import": "^2.29.1",
                 "eslint-plugin-prettier": "^5.1.3",
                 "prettier": "^3.2.5",
@@ -3608,9 +3608,10 @@
             }
         },
         "node_modules/eslint-import-resolver-typescript": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.6.1.tgz",
-            "integrity": "sha512-xgdptdoi5W3niYeuQxKmzVDTATvLYqhpwmykwsh7f6HIOStGWEIL9iqZgQDF9u9OEzrRwR8no5q2VT+bjAujTg==",
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.6.0.tgz",
+            "integrity": "sha512-QTHR9ddNnn35RTxlaEnx2gCxqFlF2SEN0SE2d17SqwyM7YOSI2GHWRYp5BiRkObTUNYPupC/3Fq2a0PpT+EKpg==",
+            "license": "ISC",
             "dependencies": {
                 "debug": "^4.3.4",
                 "enhanced-resolve": "^5.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@goparrot/eslint-config",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "description": "GoParrot shared eslint configuration",
     "author": "GoParrot Inc.",
     "license": "ISC",
@@ -66,7 +66,7 @@
         "@typescript-eslint/parser": "^7.3.1",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
-        "eslint-import-resolver-typescript": "^3.6.1",
+        "eslint-import-resolver-typescript": "3.6.0",
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-prettier": "^5.1.3",
         "prettier": "^3.2.5",


### PR DESCRIPTION
## Package Downgrade: `eslint-import-resolver-typescript`

### Issue
Recent automatic upgrade to version `3.9.1` of `eslint-import-resolver-typescript` introduced severe linting issues in the store service, resulting in approximately 6,200 ESLint errors.

### Solution
- Pinned package version to `3.6.0` in `package.json`
- This resolved the majority of linting issues, reducing error count from ~6,200 to 10 style-related warnings

### Technical Details
- Before: `"eslint-import-resolver-typescript": "^3.6.1"` (resolved to 3.9.1)
- After: `"eslint-import-resolver-typescript": "3.6.0"`

### Impact
- ✅ Restored stable linting functionality
- ✅ Minimized disruption to development workflow
- ✅ Remaining 10 style errors are manageable and can be addressed separately